### PR TITLE
fix: 🐛 disable turbo in deploy-docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -26,4 +26,5 @@ jobs:
     uses: theholocron/.github/.github/workflows/deploy-docs.yml@main
     with:
       name: node-template
+      use-turbo: false
     secrets: inherit

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
 		{ name: "release", with: { "run-build": true } },
 		{
 			name: "deploy-docs",
-			with: { name: "node-template" },
+			with: { name: "node-template", "use-turbo": false },
 			paths: ["docs/**"],
 		},
 	],


### PR DESCRIPTION
## Summary

- Adds `"use-turbo": false` to the `deploy-docs` config entry in `holocron.config.ts`
- Regenerates `deploy-docs.yml` with `use-turbo: false` passed to the reusable workflow

The reusable `deploy-docs` workflow defaults `use-turbo` to `true`, which runs `pnpm turbo build` — but node-template has no turbo. This caused every deploy-docs run to fail with `Command "turbo" not found`.

## Test plan

- [ ] CI passes
- [ ] `deploy-docs` workflow completes successfully