### PR TITLE
chore: 🔧 enable GitHub Pages via holocron config

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -26,4 +26,5 @@ jobs:
     uses: theholocron/.github/.github/workflows/deploy-docs.yml@main
     with:
       name: node-template
+      use-turbo: false
     secrets: inherit

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
 		...providers,
 		secrets: "github",
 	},
+	docs: { build: "workflow", https: true },
 	agent: "claude",
 	skills: ["git-safety", "pr-workflow", "commit-standards", "security-review"],
 });

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
 		{ name: "release", with: { "run-build": true } },
 		{
 			name: "deploy-docs",
-			with: { name: "node-template" },
+			with: { name: "node-template", "use-turbo": false },
 			paths: ["docs/**"],
 		},
 	],


### PR DESCRIPTION
## Summary

- Adds `docs: { build: "workflow" }` to `holocron.config.ts` to declare GitHub Actions as the Pages build source
- GitHub Pages has been enabled on the repo via `holocron setup` (build type: workflow)

## Test plan

- [ ] CI passes
- [ ] `deploy-docs` workflow completes and publishes to `https://docs.theholocron.dev/node-template/` on next push to `main` touching `docs/**`