### PR TITLE
docs: 📝 add overview content and fix site URL

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -3,7 +3,7 @@ import { docsTheme } from "@theholocron/docs-theme";
 import { defineConfig } from "astro/config";
 
 export default defineConfig({
-	site: "https://theholocron.github.io",
+	site: "https://docs.theholocron.dev",
 	base: "/node-template",
 	integrations: [
 		starlight({

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,6 +1,26 @@
 ---
 title: Overview
-description: <description>
+description: A Node.js library starter template with pre-configured tools, best practices, and CI/CD setup for rapid project development.
 ---
 
-<description>
+A modern Node.js library starter template for `@theholocron` repos.
+
+## What's included
+
+- TypeScript with strict config via `@theholocron/tsconfig`
+- ESLint + Prettier via `@theholocron/eslint-config` and `@theholocron/prettier-config`
+- Vitest for testing with coverage via `@theholocron/vitest-config`
+- Semantic release via `@theholocron/semantic-release-config`
+- Husky + lint-staged via `@theholocron/lint-staged-config`
+- Full CI/CD via reusable workflows in `theholocron/.github`
+- Docs site via Astro + Starlight
+
+## Usage
+
+```typescript
+import { doSomething, type SomethingOptions } from "@theholocron/node-template";
+
+function App(options: SomethingOptions) {
+	return doSomething(options);
+}
+```

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -17,10 +17,11 @@ A modern Node.js library starter template for `@theholocron` repos.
 
 ## Usage
 
+<!-- prettier-ignore -->
 ```typescript
 import { doSomething, type SomethingOptions } from "@theholocron/node-template";
 
 function App(options: SomethingOptions) {
-	return doSomething(options);
+  return doSomething(options);
 }
 ```


### PR DESCRIPTION
## Summary

- Replaces `<description>` placeholder in `docs/content/index.md` with real content (the `<description>` body was rendering as an invisible HTML tag, making the page appear empty)
- Fixes `site` in `docs/astro.config.ts` from `https://theholocron.github.io` to `https://docs.theholocron.dev`

## Test plan

- [ ] CI passes
- [ ] `https://docs.theholocron.dev/node-template/` shows the overview content after deploy