### PR TITLE
feat: ✨ publish node-template-site package for main docs site

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@theholocron/node-template-site",
   "version": "0.0.0",
-  "private": true,
   "description": "Docs site for node-template",
   "scripts": {
     "build": "astro build",

--- a/release.config.ts
+++ b/release.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from "@theholocron/semantic-release-config";
 
 export default defineConfig({
+	assets: ["CHANGELOG.md", "docs/package.json", "package.json"],
 	branches: ["main", { name: "alpha", prerelease: true }],
-	npm: { access: "public" },
 	exec: {
 		prepareCmd: "pnpm exec holocron npm bump-versions ${nextRelease.version}",
 		publishCmd: "pnpm --filter @theholocron/node-template-site publish --access public --no-git-checks",
 	},
-	assets: ["CHANGELOG.md", "package.json", "docs/package.json"],
+	npm: { access: "public" },
 });

--- a/release.config.ts
+++ b/release.config.ts
@@ -4,8 +4,7 @@ export default defineConfig({
 	branches: ["main", { name: "alpha", prerelease: true }],
 	npm: { access: "public" },
 	exec: {
-		prepareCmd:
-			"node -e \"const fs=require('fs'),p=JSON.parse(fs.readFileSync('docs/package.json','utf8'));p.version='${nextRelease.version}';fs.writeFileSync('docs/package.json',JSON.stringify(p,null,2)+'\\n')\"",
+		prepareCmd: "pnpm exec holocron npm bump-versions ${nextRelease.version}",
 		publishCmd: "pnpm --filter @theholocron/node-template-site publish --access public --no-git-checks",
 	},
 	assets: ["CHANGELOG.md", "package.json", "docs/package.json"],

--- a/release.config.ts
+++ b/release.config.ts
@@ -3,4 +3,10 @@ import { defineConfig } from "@theholocron/semantic-release-config";
 export default defineConfig({
 	branches: ["main", { name: "alpha", prerelease: true }],
 	npm: { access: "public" },
+	exec: {
+		prepareCmd:
+			"node -e \"const fs=require('fs'),p=JSON.parse(fs.readFileSync('docs/package.json','utf8'));p.version='${nextRelease.version}';fs.writeFileSync('docs/package.json',JSON.stringify(p,null,2)+'\\n')\"",
+		publishCmd: "pnpm --filter @theholocron/node-template-site publish --access public --no-git-checks",
+	},
+	assets: ["CHANGELOG.md", "package.json", "docs/package.json"],
 });


### PR DESCRIPTION
## Summary

- Removes `"private": true` from `docs/package.json` so `@theholocron/node-template-site` can be published to npm
- Extends `release.config.ts` to version and publish the docs package alongside the main package on every release:
  - `prepareCmd` — bumps `docs/package.json` version to match the release version
  - `publishCmd` — publishes `@theholocron/node-template-site` with public access
  - Adds `docs/package.json` to the git commit assets so the version bump is tracked

This enables the main docs site (`theholocron.github.io`) to load node-template content at `projects/templates/node` via the existing `createDocsLoader` package resolution — no new package or monorepo structure needed.

## Test plan

- [ ] CI passes
- [ ] On merge, semantic-release publishes both `@theholocron/node-template` and `@theholocron/node-template-site`
- [ ] `@theholocron/node-template-site` is visible on npmjs.com after release