### PR TITLE
chore: add devcontainer for GitHub Codespaces support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "node-template",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "postCreateCommand": "corepack enable && pnpm install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pnpm install --save-dev @theholocron/node-template
 import { doSomething, type SomethingOptions } from "@theholocron/node-template";
 
 function App(options: SomethingOptions) {
-	return doSomething(options);
+  return doSomething(options);
 }
 ```
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -21,6 +21,6 @@ A modern Node.js library starter template for `@theholocron` repos.
 import { doSomething, type SomethingOptions } from "@theholocron/node-template";
 
 function App(options: SomethingOptions) {
-	return doSomething(options);
+  return doSomething(options);
 }
 ```


### PR DESCRIPTION
Adds `.devcontainer/devcontainer.json` so contributors can open this repo in a GitHub Codespace without any local setup. Uses the standard Node 22 devcontainer image with `corepack enable && pnpm install` on creation.