### PR TITLE
fix(release): drop docs assets/publish, bump catalog:configs to 7.19.1 for tsconfig/astro export

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,35 +7,35 @@ settings:
 catalogs:
   configs:
     '@theholocron/astro-config':
-      specifier: ^7.8.1
+      specifier: ^7.19.1
       version: 7.19.1
     '@theholocron/commitlint-config':
-      specifier: ^7.8.1
-      version: 7.17.0
+      specifier: ^7.19.1
+      version: 7.19.1
     '@theholocron/eslint-config':
-      specifier: ^7.8.1
-      version: 7.17.0
+      specifier: ^7.19.1
+      version: 7.19.1
     '@theholocron/holocron-config':
-      specifier: ^7.8.1
-      version: 7.17.0
+      specifier: ^7.19.1
+      version: 7.19.1
     '@theholocron/lint-staged-config':
-      specifier: ^7.8.1
-      version: 7.17.0
+      specifier: ^7.19.1
+      version: 7.19.1
     '@theholocron/prettier-config':
-      specifier: ^7.8.1
-      version: 7.17.0
+      specifier: ^7.19.1
+      version: 7.19.1
     '@theholocron/semantic-release-config':
-      specifier: ^7.8.1
-      version: 7.17.0
+      specifier: ^7.19.1
+      version: 7.19.1
     '@theholocron/tsconfig':
-      specifier: ^7.8.1
-      version: 7.17.0
+      specifier: ^7.19.1
+      version: 7.19.1
     '@theholocron/tsdown-config':
-      specifier: ^7.8.1
-      version: 7.17.0
+      specifier: ^7.19.1
+      version: 7.19.1
     '@theholocron/vitest-config':
-      specifier: ^7.8.1
-      version: 7.17.0
+      specifier: ^7.19.1
+      version: 7.19.1
   default:
     '@astrojs/starlight':
       specifier: ^0.41.5
@@ -159,40 +159,40 @@ importers:
         version: 3.18.5(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.2.0)(vitest@4.1.10)
       '@theholocron/commitlint-config':
         specifier: catalog:configs
-        version: 7.17.0(@commitlint/cli@21.2.1(@types/node@26.2.0)(conventional-commits-parser@7.1.2)(typescript@5.9.3))(@commitlint/config-conventional@21.2.0)
+        version: 7.19.1(@commitlint/cli@21.2.1(@types/node@26.2.0)(conventional-commits-parser@7.1.2)(typescript@5.9.3))(@commitlint/config-conventional@21.2.0)
       '@theholocron/docs-theme':
         specifier: 'catalog:'
         version: 1.3.2(@astrojs/starlight@0.41.7(@astrojs/markdown-remark@7.2.2)(astro@7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@theholocron/eslint-config':
         specifier: catalog:configs
-        version: 7.17.0(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.66.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.19.1(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.66.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/holocron-config':
         specifier: catalog:configs
-        version: 7.17.0(@theholocron/cli@3.18.5(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.2.0)(vitest@4.1.10))
+        version: 7.19.1(@theholocron/cli@3.18.5(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.2.0)(vitest@4.1.10))
       '@theholocron/holocron-plugin-github':
         specifier: catalog:holocron
         version: 3.18.5(@theholocron/cli@3.18.5(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.2.0)(vitest@4.1.10))(@theholocron/github-client@1.6.0(vitest@4.1.10))
       '@theholocron/lint-staged-config':
         specifier: catalog:configs
-        version: 7.17.0(husky@9.1.7)(lint-staged@16.4.0)(sort-package-json@4.0.0)
+        version: 7.19.1(husky@9.1.7)(lint-staged@16.4.0)(sort-package-json@4.0.0)
       '@theholocron/prettier-config':
         specifier: catalog:configs
-        version: 7.17.0(prettier@3.9.6)
+        version: 7.19.1(prettier@3.9.6)
       '@theholocron/semantic-release-config':
         specifier: catalog:configs
-        version: 7.17.0(@semantic-release/changelog@7.0.0(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/exec@7.1.0(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/git@11.0.1(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/github@12.0.9(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.9(typescript@5.9.3)))(conventional-changelog-conventionalcommits@10.2.1)(semantic-release@25.0.9(typescript@5.9.3))
+        version: 7.19.1(@semantic-release/changelog@7.0.0(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/exec@7.1.0(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/git@11.0.1(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/github@12.0.9(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.9(typescript@5.9.3)))(conventional-changelog-conventionalcommits@10.2.1)(semantic-release@25.0.9(typescript@5.9.3))
       '@theholocron/skills':
         specifier: ^1.3.2
         version: 1.3.2
       '@theholocron/tsconfig':
         specifier: catalog:configs
-        version: 7.17.0(typescript@5.9.3)
+        version: 7.19.1(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: catalog:configs
-        version: 7.17.0(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.23.1)(typescript@5.9.3))
+        version: 7.19.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.23.1)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: catalog:configs
-        version: 7.17.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.19.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0
@@ -2106,8 +2106,8 @@ packages:
     resolution: {integrity: sha512-csfeElWzLIfGC6W3+xit6thbyhRrIHV77cF5C1GWzvH1bs99L/bxbRBxwUzr4uF9KlsPdWDOeJGHDyzlteFyfw==}
     hasBin: true
 
-  '@theholocron/commitlint-config@7.17.0':
-    resolution: {integrity: sha512-8ZHhOFbOuGvrqR8Z1F7RLQULpXZMPmUl6rdCOSdLepdEMut9Rf6iHu1NbnprLdeFcWuZkYMRJ3GWG3E+cF8qOQ==}
+  '@theholocron/commitlint-config@7.19.1':
+    resolution: {integrity: sha512-3jbOnaRMJDdLSa9AjxE3gdtVkF6FrLaVePwHuzhb/xekZHWx7ORFPahYbW4CEg16EZgLs7lg9PkZ7esmHOsnDA==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@commitlint/cli': ^21
@@ -2120,8 +2120,8 @@ packages:
       '@astrojs/starlight': '>=0.30.0'
       astro: '>=5.0.0'
 
-  '@theholocron/eslint-config@7.17.0':
-    resolution: {integrity: sha512-aeZGGAN+Fex2koLAHGFVyG902l5k9wLpbtXWgTjVrhOPAP/QqpbYgtICilYIpLuGCuGiu91pL8HrV1bFRoungA==}
+  '@theholocron/eslint-config@7.19.1':
+    resolution: {integrity: sha512-/tkJGE4Hy+gxUHzAo+ewnUI49c2aeLE3xXo/dM8X9s7Dl6I2lTyaS3/IJUs8cTMSuPQcXxDxnXt0VOP30YVYhQ==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@eslint/js': ^10
@@ -2153,8 +2153,8 @@ packages:
     resolution: {integrity: sha512-h+nbOUTR+8YlObab7OMOs2MqpCrENrtHWcTySVBesoluJZoAQ4/uaqq2U7Z9WP5UT9+WN9J7R8/QrkGlxaPXtw==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/holocron-config@7.17.0':
-    resolution: {integrity: sha512-0vzxjxpl/dCdd8t5vC5SGe+s8buwWfT/MrvbjqUx3QZc3ZWfYpQQzUxMUeRrhfI4xarg3qxhf1WwRQERMNoBMQ==}
+  '@theholocron/holocron-config@7.19.1':
+    resolution: {integrity: sha512-BDp2umeCi9Ti9NdNFLt6p/cI2FCzciZfIZ+mJbZFc4adJs93KDDFS14sWqWly6cggiSHvrseMP20VkMWTbgFHg==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@theholocron/cli': '>=2.0.0-alpha.1'
@@ -2174,8 +2174,8 @@ packages:
       vitest:
         optional: true
 
-  '@theholocron/lint-staged-config@7.17.0':
-    resolution: {integrity: sha512-xZ2EcL5N9F3Fwd8TB7J5oIx3m5dVm/lv4p7d0UY3e+ZZ5Yzt8ebVbQwnak4iZh9tsKYOjnjGjcmjF5/T93yQJQ==}
+  '@theholocron/lint-staged-config@7.19.1':
+    resolution: {integrity: sha512-SpLRN5wCxCdiVlkTPqbc5DNm3s0aLth+8HQDTW18T06Zh+y6Xn85uYyUahgv0Ct2bEzegvmvW1tdkOoxM0+HUQ==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       husky: ^9
@@ -2185,14 +2185,14 @@ packages:
       sort-package-json:
         optional: true
 
-  '@theholocron/prettier-config@7.17.0':
-    resolution: {integrity: sha512-xZ/+7/vu3qa1yB8AWZ3QkVcAfKt2iQQ56sIMm5N8GMP6H2FbV1Yo4GLX/Mlu8QVq1ttrdIZHF+1WQSiGr+WRBg==}
+  '@theholocron/prettier-config@7.19.1':
+    resolution: {integrity: sha512-IU+gxQrmjvLls3P5avBiMCOjI6GBXtCvUx9vsE9cb7g6bmVmlz8zh3mkSBq4JnjwRvYxGM3HIOjzp+ERP5PdQA==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       prettier: ^3
 
-  '@theholocron/semantic-release-config@7.17.0':
-    resolution: {integrity: sha512-hM33B2gNlCihKddwhsSjLQguBnxa80sdH6wTksKMlXVC90kyDLZzRUvd254zd9xVJt/8MlqYICaE9tuZBKzixQ==}
+  '@theholocron/semantic-release-config@7.19.1':
+    resolution: {integrity: sha512-nN6/hcrAgLDJUWkl+shJ/+Rz1bXenmaXL6KWkZ2HM2/gXWSNnuJ6+P881gl1nTYfVo/G0QQWo7rX0UFJZdrRBQ==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@semantic-release/changelog': ^6
@@ -2211,20 +2211,20 @@ packages:
     resolution: {integrity: sha512-jjnezEdoMUraGe4vmffm51KHTefXFNaHr2XNzweQSGjuzpj+F+iaBu741zXpZDtG5VCsyo5gF/sUIhEtUcw5pg==}
     engines: {node: '>=22', pnpm: '>=10'}
 
-  '@theholocron/tsconfig@7.17.0':
-    resolution: {integrity: sha512-6vngC+9xfhj9oBf4HI1rLEJlP/LIdAkwE2RBpuQm1858UKugzQ02GAYx4vwqxSTspGo+J6iSThHJ3cnVMiiJrQ==}
+  '@theholocron/tsconfig@7.19.1':
+    resolution: {integrity: sha512-8nSd3UOsmpV3MdHw4zDbBkj4QbF70LCO/vj1MIDFuRv/K7PqA+tGAuTB4YGjodWLwdQBC6wjRMQo0lK9zI92sg==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       typescript: ^5
 
-  '@theholocron/tsdown-config@7.17.0':
-    resolution: {integrity: sha512-NtS+13Ng9/gnX1MAAtrirPqUi6uBhAbuOJb51Pq5Fcm3NCjxpy3Jm3SLoz9jvpaFKVbiJaNNIHsh/g5rfRfcEg==}
+  '@theholocron/tsdown-config@7.19.1':
+    resolution: {integrity: sha512-tHLJVM/YDyt0PWNQNMwbmOS9BJpI3ZdWdCmh1g/2UOhZMnYUuqs5YhkANnRSaoIVOkwKtL23BKd3k+6TpMlZ3g==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       tsdown: ^0
 
-  '@theholocron/vitest-config@7.17.0':
-    resolution: {integrity: sha512-JWffrx/aIhYlIA1+t+AVkwagVNeyY2Ticfmi+KReKkjMKc7qbnO5qrRZha0JwpK+wLxu+VBZHWo9wsPXCI9y7w==}
+  '@theholocron/vitest-config@7.19.1':
+    resolution: {integrity: sha512-vP7EUuqFhFizQdRsbzWmJfFUPAzIFfB4kqE2Jj40P0uIfAY3jGyJWQ/7kJ84y6P3XEeBozrpeyGKMvjpSu5tAw==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@storybook/addon-vitest': ^9
@@ -7138,7 +7138,7 @@ snapshots:
       - supports-color
       - vitest
 
-  '@theholocron/commitlint-config@7.17.0(@commitlint/cli@21.2.1(@types/node@26.2.0)(conventional-commits-parser@7.1.2)(typescript@5.9.3))(@commitlint/config-conventional@21.2.0)':
+  '@theholocron/commitlint-config@7.19.1(@commitlint/cli@21.2.1(@types/node@26.2.0)(conventional-commits-parser@7.1.2)(typescript@5.9.3))(@commitlint/config-conventional@21.2.0)':
     dependencies:
       '@commitlint/cli': 21.2.1(@types/node@26.2.0)(conventional-commits-parser@7.1.2)(typescript@5.9.3)
       '@commitlint/config-conventional': 21.2.0
@@ -7149,7 +7149,7 @@ snapshots:
       astro: 7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       gray-matter: 4.0.3
 
-  '@theholocron/eslint-config@7.17.0(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.66.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))':
+  '@theholocron/eslint-config@7.19.1(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.66.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))':
     dependencies:
       '@eslint/compat': 2.1.0(eslint@10.8.1(jiti@2.7.0))
       '@eslint/js': 10.0.1(eslint@10.8.1(jiti@2.7.0))
@@ -7166,7 +7166,7 @@ snapshots:
     transitivePeerDependencies:
       - vitest
 
-  '@theholocron/holocron-config@7.17.0(@theholocron/cli@3.18.5(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.2.0)(vitest@4.1.10))':
+  '@theholocron/holocron-config@7.19.1(@theholocron/cli@3.18.5(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.2.0)(vitest@4.1.10))':
     dependencies:
       '@theholocron/cli': 3.18.5(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.2.0)(vitest@4.1.10)
 
@@ -7180,18 +7180,18 @@ snapshots:
     optionalDependencies:
       vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
-  '@theholocron/lint-staged-config@7.17.0(husky@9.1.7)(lint-staged@16.4.0)(sort-package-json@4.0.0)':
+  '@theholocron/lint-staged-config@7.19.1(husky@9.1.7)(lint-staged@16.4.0)(sort-package-json@4.0.0)':
     dependencies:
       husky: 9.1.7
       lint-staged: 16.4.0
     optionalDependencies:
       sort-package-json: 4.0.0
 
-  '@theholocron/prettier-config@7.17.0(prettier@3.9.6)':
+  '@theholocron/prettier-config@7.19.1(prettier@3.9.6)':
     dependencies:
       prettier: 3.9.6
 
-  '@theholocron/semantic-release-config@7.17.0(@semantic-release/changelog@7.0.0(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/exec@7.1.0(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/git@11.0.1(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/github@12.0.9(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.9(typescript@5.9.3)))(conventional-changelog-conventionalcommits@10.2.1)(semantic-release@25.0.9(typescript@5.9.3))':
+  '@theholocron/semantic-release-config@7.19.1(@semantic-release/changelog@7.0.0(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/exec@7.1.0(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/git@11.0.1(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/github@12.0.9(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.9(typescript@5.9.3)))(conventional-changelog-conventionalcommits@10.2.1)(semantic-release@25.0.9(typescript@5.9.3))':
     dependencies:
       '@semantic-release/changelog': 7.0.0(semantic-release@25.0.9(typescript@5.9.3))
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.9(typescript@5.9.3))
@@ -7205,15 +7205,15 @@ snapshots:
 
   '@theholocron/skills@1.3.2': {}
 
-  '@theholocron/tsconfig@7.17.0(typescript@5.9.3)':
+  '@theholocron/tsconfig@7.19.1(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@theholocron/tsdown-config@7.17.0(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.23.1)(typescript@5.9.3))':
+  '@theholocron/tsdown-config@7.19.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.23.1)(typescript@5.9.3))':
     dependencies:
       tsdown: 0.22.14(oxc-resolver@11.24.2)(tsx@4.23.1)(typescript@5.9.3)
 
-  '@theholocron/vitest-config@7.17.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)':
+  '@theholocron/vitest-config@7.19.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)':
     dependencies:
       vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,16 +33,16 @@ catalog:
 # Shared configs — release in lockstep; bump all entries together.
 catalogs:
   configs:
-    '@theholocron/astro-config': ^7.8.1
-    '@theholocron/commitlint-config': ^7.8.1
-    '@theholocron/eslint-config': ^7.8.1
-    '@theholocron/holocron-config': ^7.8.1
-    '@theholocron/lint-staged-config': ^7.8.1
-    '@theholocron/prettier-config': ^7.8.1
-    '@theholocron/semantic-release-config': ^7.8.1
-    '@theholocron/tsconfig': ^7.8.1
-    '@theholocron/tsdown-config': ^7.8.1
-    '@theholocron/vitest-config': ^7.8.1
+    '@theholocron/astro-config': ^7.19.1
+    '@theholocron/commitlint-config': ^7.19.1
+    '@theholocron/eslint-config': ^7.19.1
+    '@theholocron/holocron-config': ^7.19.1
+    '@theholocron/lint-staged-config': ^7.19.1
+    '@theholocron/prettier-config': ^7.19.1
+    '@theholocron/semantic-release-config': ^7.19.1
+    '@theholocron/tsconfig': ^7.19.1
+    '@theholocron/tsdown-config': ^7.19.1
+    '@theholocron/vitest-config': ^7.19.1
 
   holocron:
     '@theholocron/cli': ^3.18.5

--- a/release.config.ts
+++ b/release.config.ts
@@ -1,11 +1,10 @@
 import { defineConfig } from "@theholocron/semantic-release-config";
 
 export default defineConfig({
-	assets: ["CHANGELOG.md", "docs/package.json", "package.json"],
+	assets: ["CHANGELOG.md", "package.json"],
 	branches: ["main", { name: "alpha", prerelease: true }],
 	exec: {
 		prepareCmd: "pnpm exec holocron npm bump-versions ${nextRelease.version}",
-		publishCmd: "pnpm --filter @theholocron/node-template-site publish --access public --no-git-checks",
 	},
 	npm: { access: "public" },
 });


### PR DESCRIPTION
## Summary

Fixes two CI failures introduced when `docs/` became a private shim in #155:

- **Release job**: removes `docs/package.json` from `assets` and drops `publishCmd` for `@theholocron/node-template-site` — the docs package is now `private: true` and should not be published to npm
- **Deploy job**: bumps `catalog:configs` from `^7.8.1` → `^7.19.1`, resolving all `@theholocron/*` config packages to 7.19.1; `@theholocron/tsconfig@7.17.0` (the previously-pinned version) has no `./astro` export — 7.19.1 adds it, which is required by `docs/tsconfig.json`