### PR TITLE
chore: 🔧 enforce strict branch protection

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,7 +1,7 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Tool:    holocron sync-github
-# Changes: edit source in theholocron/holocron and push to alpha or main.
+# Tool:    holocron setup
+# Changes: run `holocron setup` to regenerate.
 name: Audit
 
 on: # yamllint disable-line rule:truthy
@@ -15,4 +15,6 @@ permissions:
 jobs:
   audit:
     uses: theholocron/.github/.github/workflows/audit.yml@main
+    with:
+      run-knip: true
     secrets: inherit

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 		teams: [{ slug: "gatekeepers", permission: "maintain" }],
 		topics: ["nodejs", "template", "typescript", "library"],
 		...repo,
-		protection: "balanced",
+		protection: "strict",
 		properties: {
 			...repo.properties,
 			runtime_environment: "node",

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
 		topics: ["nodejs", "template", "typescript", "library"],
 		...repo,
 		protection: "strict",
+		requiredChecks: ["audit / Knip", "audit / Audit the bundle size", "codecov/patch", "codecov/project"],
 		properties: {
 			...repo.properties,
 			runtime_environment: "node",

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
 	},
 	workflows: [
 		...workflows,
-		"audit",
+		{ name: "audit", with: { "run-knip": true } },
 		{ name: "release", with: { "run-build": true } },
 		{ name: "deploy", with: { type: "docs", name: "node-template" }, paths: ["docs/**"] },
 	],

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,17 +1,32 @@
 import type { KnipConfig } from "knip";
 
 const config: KnipConfig = {
-	entry: ["src/index.ts", "commitlint.config.ts", "holocron.config.ts"],
-	project: ["src/**/*.ts", "*.config.ts"],
+	workspaces: {
+		".": {
+			// src/index.ts, commitlint.config.ts, vitest.config.ts auto-detected by Knip plugins
+			entry: ["holocron.config.ts", "src/**/*.test.ts"],
+			project: ["src/**/*.ts", "*.config.ts"],
+			// astro.config.ts is the docs build config, not an Astro workspace — disable plugin
+			astro: false,
+		},
+		docs: {
+			// astro.config.ts lives at the repo root, not here — set entry explicitly
+			entry: ["src/content.config.ts"],
+		},
+	},
 	ignoreDependencies: [
-		// tsconfig.json "extends" — not a module import
-		"@theholocron/tsconfig",
-		// commitlint uses string-based "extends", not a module import
+		// commitlint "extends" uses string shorthand — Knip sees the bare scoped
+		// org "@theholocron" rather than "@theholocron/commitlint-config"
 		"@theholocron/commitlint-config",
-		// passed as --config arg to lint-staged in .husky/pre-commit
+		"@theholocron",
+		// passed as --config arg to lint-staged binary in .husky/pre-commit
 		"@theholocron/lint-staged-config",
+		// loaded at runtime by the holocron plugin system — not a static import
+		"@theholocron/holocron-plugin-github",
+		// skills referenced as strings in holocron.config.ts — no static import for Knip to trace
+		"@theholocron/skills",
 		// binary tools — invoked via CLI or hooks, not module imports
-		"husky",
+		"sort-package-json",
 	],
 	ignoreExportsUsedInFile: true,
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dist"
   ],
   "scripts": {
+    "audit": "knip",
     "build": "tsdown",
     "lint": "eslint .",
     "prepare": "husky",
@@ -34,6 +35,7 @@
   "devDependencies": {
     "@astrojs/starlight": "catalog:",
     "@commitlint/cli": "catalog:",
+    "@commitlint/types": "catalog:",
     "@eslint/js": "catalog:",
     "@semantic-release/changelog": "catalog:",
     "@semantic-release/exec": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ catalogs:
     '@commitlint/cli':
       specifier: ^21.2.1
       version: 21.2.1
+    '@commitlint/types':
+      specifier: ^21.2.0
+      version: 21.2.0
     '@eslint/js':
       specifier: ^10.0.0
       version: 10.0.1
@@ -136,6 +139,9 @@ importers:
       '@commitlint/cli':
         specifier: 'catalog:'
         version: 21.2.1(@types/node@26.2.0)(conventional-commits-parser@7.1.2)(typescript@5.9.3)
+      '@commitlint/types':
+        specifier: 'catalog:'
+        version: 21.2.0
       '@eslint/js':
         specifier: 'catalog:'
         version: 10.0.1(eslint@10.8.1(jiti@2.7.0))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
 catalog:
   '@astrojs/starlight': ^0.41.5
   '@commitlint/cli': ^21.2.1
+  '@commitlint/types': ^21.2.0
   '@eslint/js': ^10.0.0
   '@semantic-release/changelog': ^7.0.0
   '@semantic-release/exec': ^7.1.0


### PR DESCRIPTION
## Summary

- Sets `protection: "strict"` so PRs require DCO + Lint + Typecheck + Test to pass before merge

## Test plan

- [ ] Merge and run `holocron setup` to apply the ruleset change to GitHub