### PR TITLE
chore: update @theholocron/astro-config to 7.22.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   configs:
     '@theholocron/astro-config':
-      specifier: ^7.19.1
-      version: 7.19.1
+      specifier: ^7.22.2
+      version: 7.22.2
     '@theholocron/commitlint-config':
       specifier: ^7.19.1
       version: 7.19.1
@@ -159,7 +159,7 @@ importers:
         version: 12.0.9(semantic-release@25.0.9(typescript@5.9.3))
       '@theholocron/astro-config':
         specifier: catalog:configs
-        version: 7.19.1(astro@7.2.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 7.22.2(astro@7.2.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@theholocron/cli':
         specifier: catalog:holocron
         version: 3.24.4(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.2.0)(vitest@4.1.10)
@@ -1962,8 +1962,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@theholocron/astro-config@7.19.1':
-    resolution: {integrity: sha512-QE47/ODTNEwszna7jxlI7EDQBDtP0bs5UJy25+kgoa8AI5lDPtW2ZKHRPQ7nZc1T1hsyNF7zpUZZRwHwHisGFw==}
+  '@theholocron/astro-config@7.22.2':
+    resolution: {integrity: sha512-cU7nZqBIKZteVB3qBJ0hdSAsKv5EWN7/hreM4/3AiEevq4SDXCYriVXiGQ+MVHoTSLtZk3b4PFE2jEf+zuxg+g==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       astro: '>=5.0.0'
@@ -6940,7 +6940,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@theholocron/astro-config@7.19.1(astro@7.2.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@theholocron/astro-config@7.22.2(astro@7.2.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       astro: 7.2.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,7 @@ catalog:
   '@theholocron/docs-theme': ^1.3.0
   '@types/node': ^26.1.2
   '@vitest/coverage-v8': ^4.1.10
+  astro: ^7.1.5
   conventional-changelog-conventionalcommits: ^10.2.1
   eslint: ^10.8.0
   eslint-plugin-n: ^18.2.2
@@ -28,13 +29,12 @@ catalog:
   tsdown: ^0.22.14
   typescript: ^5.9.3
   typescript-eslint: ^8.65.0
-  astro: ^7.1.5
   vitest: ^4.1.10
 
 # Shared configs — release in lockstep; bump all entries together.
 catalogs:
   configs:
-    '@theholocron/astro-config': ^7.19.1
+    '@theholocron/astro-config': ^7.22.2
     '@theholocron/commitlint-config': ^7.19.1
     '@theholocron/eslint-config': ^7.19.1
     '@theholocron/holocron-config': ^7.19.1


### PR DESCRIPTION
## Summary

Bumps `@theholocron/astro-config` to 7.22.2, which sets `base: "/<repo>"` automatically so CSS and JS assets resolve correctly when the docs site is served at `https://docs.theholocron.dev/<repo>/`.

Fixes the 404 on `/_astro/common.css` that was breaking all deployed docs sites.
