### PR TITLE
fix(deploy): add astro config files to path triggers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,17 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Tool:    holocron sync-github
-# Changes: edit source in theholocron/holocron and push to alpha or main.
+# Tool:    holocron setup
+# Changes: run `holocron setup` to regenerate.
 name: Deploy
 
 on: # yamllint disable-line rule:truthy
   push:
     branches: [main]
+    paths:
+      - docs/**
+      - astro.config.ts
+      - pnpm-workspace.yaml
+      - pnpm-lock.yaml
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Adds `astro.config.ts`, `pnpm-workspace.yaml`, and `pnpm-lock.yaml` to the deploy workflow path triggers so that changes to docs-related config files (not just content in `docs/**`) automatically trigger a redeploy.

## Why

Lockfile-only PRs (e.g. bumping `@theholocron/astro-config`) don't touch `docs/**`, so the deploy never fired and the CSS fix never took effect on the deployed site.
