### PR TITLE
fix(ci): add issues:write to bookkeeping/lint and run-unit to test

### DIFF
--- a/.github/workflows/bookkeeping.yml
+++ b/.github/workflows/bookkeeping.yml
@@ -12,6 +12,7 @@ on: # yamllint disable-line rule:truthy
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
   statuses: write
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,6 @@ jobs:
   test:
     name: Test
     uses: theholocron/.github/.github/workflows/test.yml@main
+    with:
+      run-unit: true
     secrets: inherit


### PR DESCRIPTION
## Summary

- Adds `issues: write` to `bookkeeping.yml` so the label job can post PR comments
- Adds `issues: write` to `lint.yml` so super-linter can post PR comments
- Adds `with: run-unit: true` to `test.yml` so the reusable test workflow receives the expected input (fixes 0s "workflow file issue" on PR events)
