### PR TITLE
docs: add getting-started page and update index

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -6,7 +6,13 @@ export default defineConfig({
 	docs: {
 		name: "Node Template",
 		github: "node-template",
-		sidebar: [{ label: "Overview", slug: "" }],
+		sidebar: [
+			{ label: "Overview", slug: "" },
+			{
+				label: "Guide",
+				items: [{ label: "Getting Started", slug: "getting-started" }],
+			},
+		],
 	},
 	starlight,
 	docsTheme,

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -1,0 +1,49 @@
+---
+title: Getting Started
+description: How to use the Node template to start a new library.
+---
+
+## Use this template
+
+Use the [Holocron CLI](https://github.com/theholocron/holocron) to scaffold a new Node.js library. It clones the template, renames all placeholder references, and runs `holocron setup` in one step:
+
+```bash
+npx @theholocron/cli new node my-library \
+  --description "My library description" \
+  --homepage "https://my-library.example.com" \
+  --agent claude
+```
+
+This will:
+
+1. Create `theholocron/my-library` from this template on GitHub
+2. Replace all `node-template` references with `my-library` throughout the repo
+3. Run `pnpm install`
+4. Run `holocron setup` to configure branch protection, labels, workflows, and repo settings
+
+### Manual clone
+
+If you prefer to set things up yourself:
+
+```bash
+git clone https://github.com/theholocron/node-template.git my-library
+cd my-library
+pnpm install
+```
+
+## Development
+
+```bash
+pnpm build     # compile the library
+pnpm test      # run tests
+```
+
+## Scripts
+
+| Script               | Description                  |
+| -------------------- | ---------------------------- |
+| `pnpm build`         | Compile the library          |
+| `pnpm test`          | Run tests                    |
+| `pnpm test:coverage` | Run tests with coverage      |
+| `pnpm typecheck`     | Run TypeScript type-checking |
+| `pnpm lint`          | Run ESLint                   |

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,26 +1,36 @@
 ---
-title: Overview
-description: A Node.js library starter template with pre-configured tools, best practices, and CI/CD setup for rapid project development.
+title: Node Template
+description: A modern Node.js library starter template with pre-configured tools, best practices, and CI/CD setup.
+sidebar:
+  hidden: true
 ---
 
-A modern Node.js library starter template for `@theholocron` repos.
+`@theholocron/node-template` is an opinionated starter for Node.js libraries. It ships with a full development, testing, and release pipeline ready to go.
 
-## What's included
+## What's Included
 
-- TypeScript with strict config via `@theholocron/tsconfig`
-- ESLint + Prettier via `@theholocron/eslint-config` and `@theholocron/prettier-config`
-- Vitest for testing with coverage via `@theholocron/vitest-config`
-- Semantic release via `@theholocron/semantic-release-config`
-- Husky + lint-staged via `@theholocron/lint-staged-config`
-- Full CI/CD via reusable workflows in `theholocron/.github`
-- Docs site via Astro + Starlight
+| Tool                                                    | Purpose                                                |
+| ------------------------------------------------------- | ------------------------------------------------------ |
+| [TypeScript](https://www.typescriptlang.org)            | Type safety via `@theholocron/tsconfig`                |
+| [ESLint](https://eslint.org)                            | Linting via `@theholocron/eslint-config`               |
+| [Prettier](https://prettier.io)                         | Formatting via `@theholocron/prettier-config`          |
+| [Vitest](https://vitest.dev)                            | Testing with coverage via `@theholocron/vitest-config` |
+| [semantic-release](https://semantic-release.gitbook.io) | Automated releases                                     |
+| [Husky](https://typicode.github.io/husky)               | Git hooks via `@theholocron/lint-staged-config`        |
+| Astro + Starlight                                       | Docs site                                              |
+| CI/CD                                                   | Reusable workflows from `theholocron/.github`          |
 
-## Usage
+## Getting Started
 
-```typescript
-import { doSomething, type SomethingOptions } from "@theholocron/node-template";
-
-function App(options: SomethingOptions) {
-  return doSomething(options);
-}
+```bash
+npx @theholocron/cli new node my-library \
+  --description "My library description" \
+  --homepage "https://my-library.example.com" \
+  --agent claude
 ```
+
+See [Getting Started](./getting-started) for the full walkthrough including manual setup and available scripts.
+
+## Quick links
+
+- [Getting started](./getting-started) — scaffold a new project with the Holocron CLI


### PR DESCRIPTION
## Summary

- **`docs/content/index.md`**: replaces the bullet list with a What's Included table, adds a Getting Started CLI snippet and Quick links
- **`docs/content/getting-started.md`**: new page covering the `holocron new node` CLI flow, manual clone, and scripts table
- **`astro.config.ts`**: adds a Guide/Getting Started entry to the sidebar